### PR TITLE
Added List to ignore when merging 2 documents 

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,14 @@ B is also destroyed after the merge has been successful.
 
 ## Testing
 
-In the terminal, run `sudo mongod` to start the mongoDB connection
+In the terminal, you'll need to start a mongoDB connection
+
+To do this, you'll need to run `mongod` while specifying a local folder
+
+EX:
+
+    $ mkdir tmpdb
+    $ mongod --dbpath ./tmpdb
 
 Open another tab and run `rspec`
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ B attributes will be merged into A.
 
 B is also destroyed after the merge has been successful.
 
+## Testing
+
+In the terminal, run `sudo mongod` to start the mongoDB connection
+
+Open another tab and run `rspec`
+
 
 That's all folks!
 

--- a/lib/merge-mongoid.rb
+++ b/lib/merge-mongoid.rb
@@ -3,7 +3,7 @@ require 'mongoid'
 module Mongoid
   module Document
     module Mergeable
-
+      
       # Merge a mongoid document into another.
       # ignored_attributes: Array of attributes you want to ignore when merging 2 documents
       # A.merge!(B)
@@ -14,9 +14,9 @@ module Mongoid
           raise "Cannot merge two different models."
         elsif (!self.is_a? Mongoid::Document) || (!another_document.is_a? Mongoid::Document)
           raise "Can only merge mongoid documents."
-        else
+        else 
           # let's merge these documents
-
+          
           # A.merge!(B)
           #
           # We iterate on B attributes :
@@ -34,16 +34,16 @@ module Mongoid
               end
             end
           end
-
+          
           # saving the A model
           self.save
           # delete the B model
-          another_document.destroy
+          another_document.destroy 
         end
       end
-
+      
       private
-
+      
       def merge_attributes(a, b, hash_uniq_attr = {})
         # we might want to remove this test, and for instance merge the different types in an Array
         if ((a.class != NilClass) && (b.class != NilClass) && (a.class != b.class)) && !(((a.class == TrueClass) && (b.class == FalseClass)) || ((a.class == FalseClass) && (b.class == TrueClass)))
@@ -68,11 +68,11 @@ module Mongoid
               a = b
             end
           end
-
-          return a
+          
+          return a 
         end
       end
-
+      
       def dedupe(array, hash_uniq_attr = 'id')
         result = []
         ids = [] #where we store the uniqueness identifier
@@ -81,14 +81,14 @@ module Mongoid
             if !ids.include? value[hash_uniq_attr]
               ids << value[hash_uniq_attr]
               result << value
-            end
+            end  
           else
             if !result.include? value
               result << value
             end
           end
         end
-
+        
         result
       end
     end

--- a/spec/merge_spec.rb
+++ b/spec/merge_spec.rb
@@ -199,5 +199,21 @@ describe Mongoid::Document::Mergeable do
     end      
      
     
+    it "should not merge attributes that are included in the ignore_attributes array" do
+      @A.array_hashes = [{test1: "test1"}]
+      @B.array_hashes = [{test2: "test2"}]
+      @A.merge!(@B, {}, ['array_hashes'])
+
+      @A.array_hashes.size.should == 1
+    end
+
+    it "should  merge attributes that are not included in the ignore_attributes array" do
+      @A.array_simple_types = ["test1"]
+      @B.array_simple_types = ["test2"]
+      @A.merge!(@B, {}, ['array_hashes'])
+
+      @A.array_simple_types.size.should == 2
+    end
+
   end
 end

--- a/spec/merge_spec.rb
+++ b/spec/merge_spec.rb
@@ -207,12 +207,12 @@ describe Mongoid::Document::Mergeable do
       @A.array_hashes.size.should == 1
     end
 
-    it "should  merge attributes that are not included in the ignore_attributes array" do
-      @A.array_simple_types = ["test1"]
-      @B.array_simple_types = ["test2"]
-      @A.merge!(@B, {}, ['array_hashes'])
+    it "should merge attributes that are not included in the ignore_attributes array" do
+      @A.array_hashes = [{test1: "test1"}]
+      @B.array_hashes = [{test2: "test2"}]
+      @A.merge!(@B, {}, ['not_array_hashes'])
 
-      @A.array_simple_types.size.should == 2
+      @A.array_hashes.size.should == 2
     end
 
   end


### PR DESCRIPTION
# Added parameter to define a list of attributes to ignore when merging 2 mongo documents

Status: **Up For Review**

Reviewers: @fallanic 

## Changes
- Added `ignored_attributes` array as optional parameter to `merge!()`
- Skipping over attribute if listed in the `ignored_attributes` array

## How to test-drive this PR
- Check out the README in my commit for instructions 😉 
- All tests should pass